### PR TITLE
Feature/icon fix

### DIFF
--- a/sass/modules/icons/icons.scss
+++ b/sass/modules/icons/icons.scss
@@ -31,12 +31,14 @@
   }
 
   %action & {
+    display: inline-block;
     margin-right: 0.2rem;
     margin-left: -0.2rem;
   }
 
   &.flow-opposite {
     %action & {
+      display: inline-block;
       margin-left: 0.2rem;
       margin-right: -0.2rem;
     }

--- a/sass/modules/icons/icons.scss
+++ b/sass/modules/icons/icons.scss
@@ -38,7 +38,6 @@
 
   &.flow-opposite {
     %action & {
-      display: inline-block;
       margin-left: 0.2rem;
       margin-right: -0.2rem;
     }


### PR DESCRIPTION
In Firefox, icons on the right side of text were dropping to a new line, this fixes the incorrect behavior.